### PR TITLE
[feat] 제품 검색 시 검색한 제품 이미지 띄우기

### DIFF
--- a/moodico/urls.py
+++ b/moodico/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('upload_color_image/', views.upload_color_image, name='upload_color_image'), #색상 이미지 업로드
     path('recommend_by_color/', views.recommend_by_color, name='recommend_by_color'),  # 색상 추천
     path('search_product/', views.search_product, name='search_product'), # 제품 검색
+    path('proxy_image/', views.proxy_image, name='proxy_image'), # 검색한 제품 이미지 불러오기
     
     # 좋아요 API
     path('api/toggle_like/', views.toggle_product_like, name='toggle_product_like'),

--- a/moodico/views.py
+++ b/moodico/views.py
@@ -598,3 +598,18 @@ def liked_products_page(request):
     return render(request, 'liked_products.html', {
         'liked_products': liked_products
     })
+
+# upload.html에서 검색한 제품의 이미지를 가져옴
+def proxy_image(request):
+    image_url = request.GET.get('url')
+    if not image_url:
+        return HttpResponse("URL not provided", status=400)
+    
+    try:
+        response = requests.get(image_url, stream=True)
+        response.raise_for_status()
+        
+        content_type = response.headers.get('content-type', 'image/jpeg')
+        return HttpResponse(response.content, content_type=content_type)
+    except requests.exceptions.RequestException as e:
+        return HttpResponse(f"Error fetching image: {e}", status=500)

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -464,6 +464,7 @@
               />
             </label>
           </form>
+          <div id="search-product-image-area"></div>
         </div>
 
         <div id="image-preview-area" class="image-preview-area">
@@ -705,6 +706,27 @@
               resultsBox.style.display = "none";
               selectedProduct = item;
               analyzeSelectedProduct(item);
+
+              // 선택한 제품의 이미지를 추가
+              const searchImageInput = document.getElementById("uploaded-image");
+              const canvas = document.getElementById("image-canvas");
+
+              if (searchImageInput && canvas) {
+                // 기존 입력 초기화
+                searchImageInput.src = "";
+                //searchImageInput.style.display = "none";
+                // 기존 캔버스 초기화
+                const context = canvas.getContext('2d');
+                context.clearRect(0, 0, canvas.width, canvas.height);
+
+                const proxyUrl = `/proxy_image/?url=${encodeURIComponent(item.image)}`;
+                drawImageToCanvas(proxyUrl);
+
+                const selectedColorSwatch = document.getElementById('selected-color-swatch');
+                const hexCodeDisplay = document.getElementById('hex-code-display');
+                selectedColorSwatch.style.backgroundColor = item.hex;
+                hexCodeDisplay.textContent = item.hex;
+              }
             });
             ul.appendChild(li);
           });


### PR DESCRIPTION
## PR 올리기 전 확인하세요

- [ ] 커밋메시지가 컨벤션을 따르나요?
- [ ] 코드 컨벤션에 어긋나는 부분이 없나요?
- [ ] 로컬 머지 시 기능에 이상이 없었나요?
- [ ] PR base가 올바른가요? (development 특히 주의)

 <br/>


## 🔘담당

- [ ] FE
- [ ] BE
- [ ] Deploy

<br/>

## ❗변경사항

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 스타일링
- [ ] 리팩토링 (기능, API 변경사항 없음)
- [ ] 문서 작성

<br/>

## 🔎 작업 내용

- <내 아이템 검색> 페이지에서 아이템 검색 시 해당 아이템의 이미지로 저장된 파일을  proxy_image 뷰 함수를 통해 가져와서 이미지 영역에 띄우도록 하였습니다.
- 동시에 저장된 hex 코드를 띄우도록 처리했음

  <br/>