### PR TITLE
[Feature/kje] 무드 테스트 결과 페이지에 실제 데이터 연결(하드코딩 > 크롤링 데이터로부터의 매트릭스 영역 추천)

### DIFF
--- a/moodico/moodtest/color_analyzer.py
+++ b/moodico/moodtest/color_analyzer.py
@@ -1,0 +1,76 @@
+import json
+import random
+import math
+import logging
+logger = logging.getLogger(__name__)
+
+def product_result_by_mood(mood):
+    try:
+        mood_zones_path = 'static/data/mood_zones.json'
+        products_path = 'static/data/all_products_hex_update_tempk=4_2_1_1.json'
+
+        with open(mood_zones_path, 'r', encoding='utf-8') as f:
+            mood_zones = json.load(f)
+        
+        with open(products_path, 'r', encoding='utf-8') as f:
+            all_products = json.load(f)
+        
+        zone = mood_zones[mood]['area']
+        zone_left = zone['left']
+        zone_top = zone['top']
+        zone_right = zone_left + zone['width']
+        zone_bottom = zone_top + zone['height']
+
+        filtered_results = []
+        for product in all_products:
+            # LAB -> coords 변환 로직
+            coords = calculate_coordinates_from_lab(product['lab_l'], product['lab_a'], product['lab_b'])
+
+            if (zone_left <= coords['warmCool'] <= zone_right and
+                zone_top <= coords['lightDeep'] <= zone_bottom):
+                filtered_results.append(product)
+            
+        return filtered_results
+    
+    except Exception as e:
+        logger.error(f"제품 필터링 중 에러 발생: {e}")
+        return []
+
+# 무드필터링 된 제품을 받아서 랜덤으로 최대 3개 반환하는 함수
+# 우선은 랜덤으로 구현하였으나, 로직 수정 가능
+def get_random_products(filtered_products):
+    product_count = len(filtered_products)
+    if product_count > 3:
+        return random.sample(filtered_products, 3)
+    else:
+        return filtered_products
+
+# color_analyzer.js의 calculateCoordinatesFromLAB(l, a, b)와 동일한 역할의 함수
+def sigmoid(x):
+    return 1 / (1 + math.exp(-x))
+def enhance_contrast(value):
+    return (1 - math.cos(value * math.pi)) / 2
+def calculate_coordinates_from_lab(l, a, b):
+    l_star = l
+    a_star = a
+    b_star = b
+
+    warm_cool_score = (a_star * 0.5) + (b_star * 1.0)
+
+    # sigmoid를 활용한 비선형 매핑 - warmCool
+    spread_wc_factor = 35
+    scaled_wc_score = (warm_cool_score - 35) / spread_wc_factor
+    sigmoid_wc_middle_value = sigmoid(scaled_wc_score)
+    sigmoid_wc_value = enhance_contrast(sigmoid_wc_middle_value) + 0.03
+
+    # 선형 매핑 간격 조정 - lightDeep
+    scale = 1.1
+    offset = -7
+    light_score = (l_star * scale) + offset
+
+    light_score = max(0, min(100, light_score))
+
+    warm_cool = sigmoid_wc_value * 100
+    light_deep = 100 - light_score
+
+    return {'warmCool': warm_cool, 'lightDeep': light_deep}

--- a/moodico/moodtest/views.py
+++ b/moodico/moodtest/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from moodico.users.models import UserProfile
+from .color_analyzer import product_result_by_mood, get_random_products
 import logging
 logger = logging.getLogger(__name__)
 # Create your views here.
@@ -24,141 +25,144 @@ def mood_result(request):
     else:
         mood = '러블리'  # 기본값
     
+    mood_filtered_products = product_result_by_mood(mood)
+
     # 무드별 결과 데이터 정의
-    mood_results = {
+    mood_definition = {
         '러블리': {
             'mood_name': '🌿 모리걸 무드',
             'mood_description': '자연 속에서 살 것 같은 따뜻하고 조용한 소녀 같은 분위기',
             'makeup_recommendation': '브라운/코랄 계열, 톤다운 블러셔, 무광 립',
             'keywords': ['내추럴', '잔잔함', '따뜻한 무드'],
-            'recommended_products': [
-                {
-                    'brand': '롬앤',
-                    'product_name': '베러댄블러셔 #넛티 누드',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '9,900원'
-                },
-                {
-                    'brand': '웨이크메이크',
-                    'product_name': '무드스타일러 #우디브라운',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '12,000원'
-                },
-                {
-                    'brand': '뮤드',
-                    'product_name': '글래스팅 멜팅밤 #애쉬로즈',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '8,900원'
-                }
-            ]
+            # 'recommended_products': [
+            #     {
+            #         'brand': '롬앤',
+            #         'product_name': '베러댄블러셔 #넛티 누드',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '9,900원'
+            #     },
+            #     {
+            #         'brand': '웨이크메이크',
+            #         'product_name': '무드스타일러 #우디브라운',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '12,000원'
+            #     },
+            #     {
+            #         'brand': '뮤드',
+            #         'product_name': '글래스팅 멜팅밤 #애쉬로즈',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '8,900원'
+            #     }
+            # ]
         },
         '시크': {
             'mood_name': '🖤 시크 무드',
             'mood_description': '도시적이고 세련된 분위기의 강렬하고 매력적인 느낌',
             'makeup_recommendation': '딥한 브라운/버건디 계열, 메탈릭 섀도우, 매트 립',
             'keywords': ['세련됨', '강렬함', '도시적'],
-            'recommended_products': [
-                {
-                    'brand': '클리오',
-                    'product_name': '프로 아이 팔레트 #브라운',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '15,000원'
-                },
-                {
-                    'brand': '에뛰드',
-                    'product_name': '블러셔 #로즈브라운',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '10,000원'
-                },
-                {
-                    'brand': '롬앤',
-                    'product_name': '매트 립스틱 #딥브라운',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '11,000원'
-                }
-            ]
+            # 'recommended_products': [
+            #     {
+            #         'brand': '클리오',
+            #         'product_name': '프로 아이 팔레트 #브라운',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '15,000원'
+            #     },
+            #     {
+            #         'brand': '에뛰드',
+            #         'product_name': '블러셔 #로즈브라운',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '10,000원'
+            #     },
+            #     {
+            #         'brand': '롬앤',
+            #         'product_name': '매트 립스틱 #딥브라운',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '11,000원'
+            #     }
+            # ]
         },
         '내추럴': {
             'mood_name': '🌱 내추럴 무드',
             'mood_description': '자연스럽고 편안한 느낌의 깔끔하고 소박한 분위기',
             'makeup_recommendation': '누드/베이지 계열, 쉬머 블러셔, 글로시 립',
             'keywords': ['자연스러움', '편안함', '깔끔함'],
-            'recommended_products': [
-                {
-                    'brand': '이니스프리',
-                    'product_name': '내추럴 블러셔 #베이지',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '8,500원'
-                },
-                {
-                    'brand': '롬앤',
-                    'product_name': '글래스팅 멜팅밤 #누드',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '9,900원'
-                },
-                {
-                    'brand': '페리페라',
-                    'product_name': '글로시 틴트 #베이지',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '7,500원'
-                }
-            ]
+            # 'recommended_products': [
+            #     {
+            #         'brand': '이니스프리',
+            #         'product_name': '내추럴 블러셔 #베이지',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '8,500원'
+            #     },
+            #     {
+            #         'brand': '롬앤',
+            #         'product_name': '글래스팅 멜팅밤 #누드',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '9,900원'
+            #     },
+            #     {
+            #         'brand': '페리페라',
+            #         'product_name': '글로시 틴트 #베이지',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '7,500원'
+            #     }
+            # ]
         },
         '활기찬': {
             'mood_name': '✨ 활기찬 무드',
             'mood_description': '밝고 경쾌한 느낌의 생동감 있고 에너지 넘치는 분위기',
             'makeup_recommendation': '코랄/오렌지 계열, 글로우 블러셔, 글로시 립',
             'keywords': ['밝음', '경쾌함', '에너지'],
-            'recommended_products': [
-                {
-                    'brand': '롬앤',
-                    'product_name': '더 쥬시 래스팅 틴트 #코랄',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '9,900원'
-                },
-                {
-                    'brand': '클리오',
-                    'product_name': '글로우 블러셔 #피치',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '12,000원'
-                },
-                {
-                    'brand': '에뛰드',
-                    'product_name': '글래스 틴트 #오렌지',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '8,000원'
-                }
-            ]
+            # 'recommended_products': [
+            #     {
+            #         'brand': '롬앤',
+            #         'product_name': '더 쥬시 래스팅 틴트 #코랄',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '9,900원'
+            #     },
+            #     {
+            #         'brand': '클리오',
+            #         'product_name': '글로우 블러셔 #피치',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '12,000원'
+            #     },
+            #     {
+            #         'brand': '에뛰드',
+            #         'product_name': '글래스 틴트 #오렌지',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '8,000원'
+            #     }
+            # ]
         },
         '고급스러운': {
             'mood_name': '💎 고급스러운 무드',
             'mood_description': '우아하고 세련된 느낌의 럭셔리하고 매력적인 분위기',
             'makeup_recommendation': '딥레드/버건디 계열, 메탈릭 섀도우, 크림 립',
             'keywords': ['우아함', '세련됨', '럭셔리'],
-            'recommended_products': [
-                {
-                    'brand': '에뛰드',
-                    'product_name': '프리미엄 립스틱 #딥레드',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '18,000원'
-                },
-                {
-                    'brand': '클리오',
-                    'product_name': '메탈릭 섀도우 #골드',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '15,000원'
-                },
-                {
-                    'brand': '롬앤',
-                    'product_name': '크림 블러셔 #버건디',
-                    'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
-                    'price': '11,000원'
-                }
-            ]
+            # 'recommended_products': [
+            #     {
+            #         'brand': '에뛰드',
+            #         'product_name': '프리미엄 립스틱 #딥레드',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '18,000원'
+            #     },
+            #     {
+            #         'brand': '클리오',
+            #         'product_name': '메탈릭 섀도우 #골드',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '15,000원'
+            #     },
+            #     {
+            #         'brand': '롬앤',
+            #         'product_name': '크림 블러셔 #버건디',
+            #         'image': 'https://romand.io/images/product/994/2hVgwjntZmhpGANTN6g0dJii6FWJRdKWcoJIDJVM.jpg',
+            #         'price': '11,000원'
+            #     }
+            # ]
         }
     }
     
     # 선택된 무드의 결과 데이터 가져오기
-    result_data = mood_results.get(mood, mood_results['러블리'])
+    result_data = mood_definition.get(mood, mood_definition['러블리'])
+    result_data['recommended_products'] = get_random_products(mood_filtered_products)
     
     return render(request, 'moodtest/mood_result.html', result_data)

--- a/static/css/moodtest/mood_result.css
+++ b/static/css/moodtest/mood_result.css
@@ -327,6 +327,7 @@
 }
 
 .product-card {
+    position: relative;
     background: white;
     border-radius: 15px;
     padding: 16px;
@@ -379,16 +380,20 @@
 }
 
 .purchase-btn {
+    display: block;
+    width: 100%;
     padding: 8px 12px;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
     border: none;
     border-radius: 8px;
-    font-size: 13px;
-    font-weight: 600;
     cursor: pointer;
     transition: all 0.3s;
-    width: 100%;
+    color: white;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: center;
+    text-decoration: none;
+    box-sizing: border-box;
 }
 
 .purchase-btn:hover {

--- a/static/data/mood_zones.json
+++ b/static/data/mood_zones.json
@@ -1,0 +1,32 @@
+{
+    "러블리": {
+        "name": "러블리",
+        "area": { "left": 60, "top": 10, "width": 30, "height": 40 },
+        "color": "#FFE5E5",
+        "description": "상큼하고 기분 좋은 무드"
+    },
+    "활기찬": {
+        "name": "활기찬", 
+        "area": { "left": 70, "top": 30, "width": 25, "height": 30 },
+        "color": "#FFF2E5",
+        "description": "밝고 친근한 무드"
+    },
+    "고급스러운": {
+        "name": "고급스러운",
+        "area": { "left": 65, "top": 60, "width": 30, "height": 35 },
+        "color": "#E5D4C8",
+        "description": "포인트 있는 강렬한 무드"
+    },
+    "내추럴": {
+        "name": "내추럴",
+        "area": { "left": 20, "top": 10, "width": 35, "height": 40 },
+        "color": "#E5F0FF",
+        "description": "자연스러운 무드"
+    },
+    "시크": {
+        "name": "시크",
+        "area": { "left": 15, "top": 60, "width": 35, "height": 35 },
+        "color": "#E5E5F0",
+        "description": "스타일리시한 무드"
+    }
+}

--- a/static/js/recommendation/color_matrix_script.js
+++ b/static/js/recommendation/color_matrix_script.js
@@ -11,7 +11,7 @@ const getCoords = (hex) => {
 };
 */
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const matrixContainer = document.querySelector('.color-matrix-container');
     const productsContainer = document.getElementById('makeup-products-container');
     const moodSelectionArea = document.getElementById('mood-selection-area');
@@ -25,7 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const productsContainerLips = document.getElementById('makeup-products-container-lips');
     const productsContainerEyeshadow = document.getElementById('makeup-products-container-eyeshadow');
     const productsContainerBlush = document.getElementById('makeup-products-container-blush');
-    // 무드별 구역 정의
+    /*
+    // 무드별 구역 정의 -> mood_zones.json로 이동
     const moodZones = {
         '러블리': {
             name: '러블리',
@@ -58,6 +59,19 @@ document.addEventListener('DOMContentLoaded', () => {
             description: '스타일리시한 무드'
         }
     };
+    */
+
+    let moodZones;
+    try{
+        const response = await fetch('/static/data/mood_zones.json');
+        if (!response.ok){
+            throw new Error(`error: ${response.status}`)
+        }
+        moodZones = await response.json();
+    } catch (error){
+        console.error("moodZones.json 파일을 불러오는 데 실패했습니다:", error);
+        return;
+    }
 
 
     /*

--- a/templates/moodtest/mood_result.html
+++ b/templates/moodtest/mood_result.html
@@ -45,7 +45,7 @@
           <div class="product-brand">{{ product.brand }}</div>
           <div class="product-name">{{ product.name }}</div>
           <div class="product-price">{{ product.price }}</div>
-          <button class="purchase-btn">구매하기</button>
+          <a class="purchase-btn" href="{{ product.url }}">구매하기</a>
         </div>
         {% empty %}
         <p>추천 제품을 준비 중입니다.</p>

--- a/templates/moodtest/mood_result.html
+++ b/templates/moodtest/mood_result.html
@@ -33,17 +33,17 @@
         {% for product in recommended_products %}
         <div
           class="product-card"
-          data-product-id="{{ product.brand|slugify }}-{{ product.product_name|slugify }}-{{ product.price|slugify }}-mood{{ forloop.counter }}"
+          data-product-id="{{ product.brand|slugify }}-{{ product.name|slugify }}-{{ product.price|slugify }}-mood{{ forloop.counter }}"
         >
           <button class="like-button" title="좋아요"></button>
           <span class="like-count">0</span>
           <img
             src="{{ product.image }}"
-            alt="{{ product.product_name }}"
+            alt="{{ product.name }}"
             class="product-image"
           />
           <div class="product-brand">{{ product.brand }}</div>
-          <div class="product-name">{{ product.product_name }}</div>
+          <div class="product-name">{{ product.name }}</div>
           <div class="product-price">{{ product.price }}</div>
           <button class="purchase-btn">구매하기</button>
         </div>

--- a/templates/recommendation/color_matrix.html
+++ b/templates/recommendation/color_matrix.html
@@ -103,7 +103,7 @@
 {% endblock %} {% block extra_js %}
 <script>
   const makeupProducts = {{ makeupProducts| safe }};
-  console.log(makeupProducts);  // 확인용
+  //console.log(makeupProducts);  // 확인용
 </script>
 <script src="{% static 'js/recommendation/color_analyzer.js' %}"></script>
 <script src="{% static 'js/recommendation/color_matrix_script.js' %}"></script>


### PR DESCRIPTION
## PR 올리기 전 확인하세요

- [ ] 커밋메시지가 컨벤션을 따르나요?
- [ ] 코드 컨벤션에 어긋나는 부분이 없나요?
- [x] 로컬 머지 시 기능에 이상이 없었나요?
- [x] PR base가 올바른가요? (development 특히 주의)

 <br/>


## 🔘담당

- [ ] FE
- [x] BE
- [ ] Deploy

<br/>

## ❗변경사항

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 스타일링
- [x] 리팩토링 (기능, API 변경사항 없음)
- [ ] 문서 작성

<br/>

## 🔎 작업 내용

- color_matrix_scripts.js에 있던 무드별로 정의된 구역을 다른 코드에서도 참조할 수 있도록 data/mood_zones.json으로 옮긴 후 리펙토링
- 무드 테스트 결과 데이터를 실제 데이터로부터 받아올 수 있도록 뷰함수 수정, 추가로 필요한 함수 정의(color_analyzer.py)
- 현재는무드 테스트 결과에 해당하는 필터링 데이터로부터 3개 제품을 랜덤으로 가져오도록 함
-  무드 테스트 결과페이지에서 구매하기 버튼 클릭시 저장된 url로 이동하도록 button 태그 a태그로 수정

  <br/>